### PR TITLE
fix buddybuild script

### DIFF
--- a/buddybuild_postclone.sh
+++ b/buddybuild_postclone.sh
@@ -8,5 +8,5 @@ sh ${gitPath}/generate_last_commit.sh
 
 # Use event capture SDK branch
 cd sdk
-git checkout legacy-event
+git checkout 2.22-legacy
 cd -


### PR DESCRIPTION
BB needs to know about the SDK branch used to generate the release. It was set to EyeSeeTea fork branch name. This PR fix that pointing to the DHIS2 branch name on the SDK