### PR TITLE
Legacy event

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,8 +38,8 @@ android {
         applicationId "org.hisp.dhis.android.eventcapture"
         minSdkVersion 15
         targetSdkVersion 25
-        versionCode 24
-        versionName "0.3.6"
+        versionCode 25
+        versionName "0.3.7"
     }
     buildTypes {
         release {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,7 @@
  */
 
 apply plugin: 'com.android.application'
+apply plugin: 'jacoco-android'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -36,19 +37,23 @@ android {
     defaultConfig {
         applicationId "org.hisp.dhis.android.eventcapture"
         minSdkVersion 15
-        targetSdkVersion 21
+        targetSdkVersion 25
         versionCode 24
-        versionName "0.3.5-2.22"
+        versionName "0.3.6"
     }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        debug {
+            testCoverageEnabled true
+        }
     }
 
     lintOptions {
         disable 'RtlSymmetry', 'RtlHardcoded'
+        abortOnError false
     }
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,7 +29,8 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.hisp.dhis.android.eventcapture" >
+    xmlns:tools="http://schemas.android.com/tools"
+    package="org.hisp.dhis.android.eventcapture">
 
     <uses-sdk
         android:targetSdkVersion="21" />
@@ -43,7 +44,8 @@
 
     <application
         android:name="org.hisp.dhis.android.eventcapture.EventCaptureApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
+        tools:replace="android:allowBackup"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >

--- a/app/src/main/java/org/hisp/dhis/android/eventcapture/MainActivity.java
+++ b/app/src/main/java/org/hisp/dhis/android/eventcapture/MainActivity.java
@@ -29,9 +29,13 @@
 
 package org.hisp.dhis.android.eventcapture;
 
+import android.Manifest;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 
@@ -48,10 +52,20 @@ import org.hisp.dhis.android.sdk.ui.fragments.loading.LoadingFragment;
 public class MainActivity extends AppCompatActivity implements INavigationHandler {
     public final static String TAG = MainActivity.class.getSimpleName();
     private OnBackPressedListener mBackPressedListener;
+    private static final int REQUEST_ACCESS_FINE_LOCATION = 1;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        boolean hasPermissionLocation = (ContextCompat.checkSelfPermission(MainActivity.this,
+                Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED);
+        if (!hasPermissionLocation) {
+            ActivityCompat.requestPermissions(MainActivity.this,
+                    new String[]{Manifest.permission.ACCESS_FINE_LOCATION},
+                    REQUEST_ACCESS_FINE_LOCATION);
+        }
+
         setContentView(R.layout.activity_main);
 
         LoadingController.enableLoading(this, ResourceType.ASSIGNEDPROGRAMS);

--- a/app/src/main/java/org/hisp/dhis/android/eventcapture/fragments/SelectProgramFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/eventcapture/fragments/SelectProgramFragmentQuery.java
@@ -174,10 +174,9 @@ class SelectProgramFragmentQuery implements Query<SelectProgramFragmentForm> {
         }
 
         if (elementsToShow.isEmpty()) {
-            DateTimeFormatter formatter = DateTimeFormat.forPattern(Event.EVENT_DATE_FORMAT);
-            DateTime dt = formatter.parseDateTime(event.getEventDate());
-            eventItem.setFirstItem(dt.toLocalDate().toString());
+            eventItem.setFirstItem(getEventDateString(event));
         }
+
         for (int i = 0; i < 3; i++) {
             if (i >= elementsToShow.size()) {
                 break;
@@ -227,6 +226,33 @@ class SelectProgramFragmentQuery implements Query<SelectProgramFragmentForm> {
             }
         }
         return eventItem;
+    }
+
+    private String getEventDateString(Event event){
+        String dateString = "Invalid date format";
+        DateTimeFormatter formatter = null;
+        DateTime dt;
+        if (dateFormatIsValid(event.getEventDate(), Event.EVENT_DATETIME_FORMAT)) {
+            formatter = DateTimeFormat.forPattern(Event.EVENT_DATETIME_FORMAT);
+        } else if (dateFormatIsValid(event.getEventDate(), Event.EVENT_DATE_FORMAT)){
+            formatter = DateTimeFormat.forPattern(Event.EVENT_DATE_FORMAT);
+        }
+        if (formatter != null) {
+            dt = formatter.parseDateTime(event.getEventDate());
+            dateString = dt.toLocalDate().toString();
+        }
+
+        return dateString;
+    }
+
+    private boolean dateFormatIsValid(String date, String format){
+        try {
+            DateTimeFormatter formatter = DateTimeFormat.forPattern(format);
+            formatter.parseDateTime(date);
+            return true;
+        } catch (IllegalArgumentException exception){
+            return false;
+        }
     }
 
     private DataValue getDataValue(Event event, String dataElement) {

--- a/app/src/main/java/org/hisp/dhis/android/eventcapture/fragments/SelectProgramFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/eventcapture/fragments/SelectProgramFragmentQuery.java
@@ -36,21 +36,23 @@ import com.raizlabs.android.dbflow.sql.language.Select;
 import org.hisp.dhis.android.sdk.controllers.metadata.MetaDataController;
 import org.hisp.dhis.android.sdk.controllers.tracker.TrackerController;
 import org.hisp.dhis.android.sdk.events.OnRowClick;
-import org.hisp.dhis.android.sdk.persistence.models.DataElement;
-import org.hisp.dhis.android.sdk.persistence.models.OptionSet;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.events.TrackedEntityInstanceColumnNamesRow;
-import org.hisp.dhis.android.sdk.ui.fragments.selectprogram.SelectProgramFragmentForm;
 import org.hisp.dhis.android.sdk.persistence.loaders.Query;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.events.EventItemRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.events.EventRow;
+import org.hisp.dhis.android.sdk.persistence.models.DataElement;
 import org.hisp.dhis.android.sdk.persistence.models.DataValue;
 import org.hisp.dhis.android.sdk.persistence.models.Event;
 import org.hisp.dhis.android.sdk.persistence.models.FailedItem;
 import org.hisp.dhis.android.sdk.persistence.models.Option;
+import org.hisp.dhis.android.sdk.persistence.models.OptionSet;
 import org.hisp.dhis.android.sdk.persistence.models.Program;
 import org.hisp.dhis.android.sdk.persistence.models.ProgramStage;
 import org.hisp.dhis.android.sdk.persistence.models.ProgramStageDataElement;
+import org.hisp.dhis.android.sdk.ui.adapters.rows.events.EventItemRow;
+import org.hisp.dhis.android.sdk.ui.adapters.rows.events.EventRow;
+import org.hisp.dhis.android.sdk.ui.adapters.rows.events.TrackedEntityInstanceColumnNamesRow;
+import org.hisp.dhis.android.sdk.ui.fragments.selectprogram.SelectProgramFragmentForm;
 import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -113,6 +115,10 @@ class SelectProgramFragmentQuery implements Query<SelectProgramFragmentForm> {
                 }
             }
         }
+        if (elementsToShow.isEmpty()) {
+            columnNames.setFirstItem(context.getResources().getString(
+                    org.hisp.dhis.android.sdk.R.string.eventDate));
+        }
         eventEventRows.add(columnNames);
         List<Event> events = TrackerController.getEvents(
                 mOrgUnitId, mProgramId
@@ -167,9 +173,21 @@ class SelectProgramFragmentQuery implements Query<SelectProgramFragmentForm> {
             eventItem.setStatus(OnRowClick.ITEM_STATUS.OFFLINE);
         }
 
+        if (elementsToShow.isEmpty()) {
+            DateTimeFormatter formatter = DateTimeFormat.forPattern(Event.EVENT_DATE_FORMAT);
+            DateTime dt = formatter.parseDateTime(event.getEventDate());
+            eventItem.setFirstItem(dt.toLocalDate().toString());
+        }
         for (int i = 0; i < 3; i++) {
             if (i >= elementsToShow.size()) {
                 break;
+            }
+            if (i == 0) {
+                eventItem.setFirstItem("");
+            } else if (i == 1) {
+                eventItem.setSecondItem("");
+            } else if (i == 2) {
+                eventItem.setThirdItem("");
             }
             String dataElementUid = elementsToShow.get(i);
             if (dataElementUid != null) {

--- a/app/src/main/java/org/hisp/dhis/android/eventcapture/fragments/SelectProgramFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/eventcapture/fragments/SelectProgramFragmentQuery.java
@@ -33,6 +33,7 @@ import android.content.Context;
 
 import com.raizlabs.android.dbflow.sql.language.Select;
 
+import org.hisp.dhis.android.eventcapture.R;
 import org.hisp.dhis.android.sdk.controllers.metadata.MetaDataController;
 import org.hisp.dhis.android.sdk.controllers.tracker.TrackerController;
 import org.hisp.dhis.android.sdk.events.OnRowClick;
@@ -174,7 +175,7 @@ class SelectProgramFragmentQuery implements Query<SelectProgramFragmentForm> {
         }
 
         if (elementsToShow.isEmpty()) {
-            eventItem.setFirstItem(getEventDateString(event));
+            eventItem.setFirstItem(getEventDateString(context, event));
         }
 
         for (int i = 0; i < 3; i++) {
@@ -228,8 +229,8 @@ class SelectProgramFragmentQuery implements Query<SelectProgramFragmentForm> {
         return eventItem;
     }
 
-    private String getEventDateString(Event event){
-        String dateString = "Invalid date format";
+    private String getEventDateString(Context context, Event event){
+        String dateString = context.getString(R.string.invalid_date_format);
         DateTimeFormatter formatter = null;
         DateTime dt;
         if (dateFormatIsValid(event.getEventDate(), Event.EVENT_DATETIME_FORMAT)) {

--- a/app/src/main/java/org/hisp/dhis/android/eventcapture/fragments/dialogs/ItemStatusDialogFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/eventcapture/fragments/dialogs/ItemStatusDialogFragment.java
@@ -2,17 +2,9 @@ package org.hisp.dhis.android.eventcapture.fragments.dialogs;
 
 import android.os.Bundle;
 
-import org.hisp.dhis.android.sdk.controllers.DhisController;
-import org.hisp.dhis.android.sdk.controllers.tracker.TrackerController;
-import org.hisp.dhis.android.sdk.job.JobExecutor;
-import org.hisp.dhis.android.sdk.job.NetworkJob;
-import org.hisp.dhis.android.sdk.network.APIException;
 import org.hisp.dhis.android.sdk.persistence.models.BaseSerializableModel;
-import org.hisp.dhis.android.sdk.persistence.models.Enrollment;
 import org.hisp.dhis.android.sdk.persistence.models.Event;
 import org.hisp.dhis.android.sdk.persistence.models.FailedItem;
-import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityInstance;
-import org.hisp.dhis.android.sdk.persistence.preferences.ResourceType;
 
 /**
  * Created by erling on 9/21/15.

--- a/app/src/main/res/raw/description
+++ b/app/src/main/res/raw/description
@@ -7,4 +7,3 @@ Login: android <br/>
 Password: Android123 <br/><br/>
 
 Developed by University of Oslo(UiO) (http://www.uio.no).<br/><br/>
-Maintained by EyeSeeTea Ltd (http://eyeseetea.com).<br/><br/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,4 +40,5 @@
     <string name="error_exporting_data">"Error metadata could not be exported."</string>
     <string name="export_data_name">Export database</string>
     <string name="developers_settings">Developers options</string>
+    <string name="invalid_date_format">"Invalid date format"</string>
 </resources>

--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Upload CodeCov report
+echo "ConnectedCheck: "
+./gradlew connectedCheck
+
+echo "Send report to CodeCov"
+bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN}

--- a/buddybuild_postclone.sh
+++ b/buddybuild_postclone.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Definitions
 gitPath=$(git rev-parse --show-toplevel)
@@ -10,3 +10,6 @@ sh ${gitPath}/generate_last_commit.sh
 cd sdk
 git checkout legacy-event
 cd -
+
+echo "Generate Test Coverage Report:"
+./gradlew build jacocoTestReport assembleAndroidTest

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,10 @@ buildscript {
         maven { url "https://raw.github.com/Raizlabs/maven-releases/master/releases" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.raizlabs:Griddle:1.0.3'
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4'
+        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
+        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -24,12 +25,12 @@ allprojects {
 ext {
     // SDK version.
     versionCode = 1
-    versionName = "1.0"
+    versionName = "0.3.6"
 
     // Compilation configuration.
     minSdkVersion = 15
-    compileSdkVersion = 22
-    targetSdkVersion = 22
-    buildToolsVersion = "22.0.1"
+    compileSdkVersion = 25
+    targetSdkVersion = 25
+    buildToolsVersion = "25.0.0"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,8 @@ allprojects {
 
 ext {
     // SDK version.
-    versionCode = 1
-    versionName = "0.3.6"
+    versionCode = 2
+    versionName = "0.3.7"
 
     // Compilation configuration.
     minSdkVersion = 15

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
This PR includes the solution to the following issues:

**New features:**
- When there's no DE with "display in reports" show the event date instead of blanks
- Compatibility with 2.27 programs with sections

**Bugfixing:**
- GPS icon for coordinate data element in Event Capture causes crash (https://jira.dhis2.org/browse/ACA-120)
- Modifying a data element causes the program to disappear on the android (https://jira.dhis2.org/browse/ACA-60)
- Information displayed on the Event Capture 'home screen' for previously registered events is incomplete (https://jira.dhis2.org/browse/ACA-59)
- Differences in sort order between android and web (https://jira.dhis2.org/browse/ACA-58)
- Option set drop-downs are appearing as free text fields in 2.26 (https://jira.dhis2.org/browse/ACA-57)
- Programme rule to hide data elements is not working in 2.26 (https://jira.dhis2.org/browse/ACA-56)
- ViewHolder pattern (scrolling down & app in lists produces dataValues to change)
- Edited events are not removed from the app on sync remote deleted events click
- Next textfield button on keyboard is only taking into account the textfields displayed in the screen
- Remove DB on app uninstall
- Introduce unsupported value type for not supported value types
