### PR TITLE
Legacy event

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,7 +35,7 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        applicationId "org.hisp.dhis.android.eventcapture"
+        applicationId "org.hisp.dhis.android.eventcapture_dev"
         minSdkVersion 15
         targetSdkVersion 25
         versionCode 28

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,8 +38,8 @@ android {
         applicationId "org.hisp.dhis.android.eventcapture_dev"
         minSdkVersion 15
         targetSdkVersion 25
-        versionCode 28
-        versionName "0.3.9"
+        versionCode 29
+        versionName "0.4.0"
     }
     buildTypes {
         release {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -90,7 +90,7 @@
 
         <provider
             android:name="org.hisp.dhis.android.eventcapture.export.DBProvider"
-            android:authorities="org.hisp.dhis.android.eventcapture.export.ExportData"
+            android:authorities="${applicationId}.export.ExportData"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/app/src/main/java/org/hisp/dhis/android/eventcapture/MainActivity.java
+++ b/app/src/main/java/org/hisp/dhis/android/eventcapture/MainActivity.java
@@ -94,11 +94,6 @@ public class MainActivity extends AppCompatActivity implements INavigationHandle
     @Override
     public void onResume() {
         super.onResume();
-        loadInitialData();
-    }
-
-    public void loadInitialData() {
-        DhisService.loadInitialData(MainActivity.this);
     }
 
     public void showLoadingFragment() {

--- a/app/src/main/java/org/hisp/dhis/android/eventcapture/export/ExportData.java
+++ b/app/src/main/java/org/hisp/dhis/android/eventcapture/export/ExportData.java
@@ -252,7 +252,7 @@ public class ExportData {
         Log.d(TAG, data.toURI() + "");
         data.setReadable(true, false);
         final Uri uri = FileProvider.getUriForFile(activity,
-                "org.hisp.dhis.android.eventcapture.export.ExportData", data);
+                "org.hisp.dhis.android.eventcapture_dev.export.ExportData", data);
 
         final Intent chooser = ShareCompat.IntentBuilder.from(activity)
                 .setType("application/zip")

--- a/app/src/main/java/org/hisp/dhis/android/eventcapture/fragments/SelectProgramFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/eventcapture/fragments/SelectProgramFragmentQuery.java
@@ -245,7 +245,7 @@ class SelectProgramFragmentQuery implements Query<SelectProgramFragmentForm> {
             DateTimeFormatter formatter = DateTimeFormat.forPattern(format);
             formatter.parseDateTime(date);
             return true;
-        } catch (IllegalArgumentException exception){
+        } catch (Exception exception){
             return false;
         }
     }

--- a/app/src/main/res/layout/fragment_about_us.xml
+++ b/app/src/main/res/layout/fragment_about_us.xml
@@ -72,6 +72,15 @@
                 app:font="@string/medium_font_name" />
 
             <org.hisp.dhis.android.sdk.ui.views.FontTextView
+                android:id="@+id/app_session"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingBottom="@dimen/about_us_text_view_bottom_padding"
+                android:textSize="15sp"
+                app:font="@string/medium_font_name"
+                />
+
+            <org.hisp.dhis.android.sdk.ui.views.FontTextView
                 android:id="@+id/commit_hash"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,7 +30,7 @@
 
 <resources>
 
-    <string name="app_name">DHIS 2 Event Capture</string>
+    <string name="app_name">DHIS 2 Event Capture (dev)</string>
     <string name="register_new_event">Register new event</string>
 
     <string name="status_sent_description">This item has been successfully synchronized with the server.</string>

--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,8 @@ allprojects {
 
 ext {
     // SDK version.
-    versionCode = 5
-    versionName = "0.3.9"
+    versionCode = 6
+    versionName = "0.4.0"
 
     // Compilation configuration.
     minSdkVersion = 15


### PR DESCRIPTION
New features:
- 2.28 servers compatibility
- Wait on login showing progress bar on initial sync (https://jira.dhis2.org/browse/ACA-134)
- Completed events expiry days implemented (https://jira.dhis2.org/browse/ACA-132)
- Make buddybuild version compatible with Google Play version in the same device

Bugfixing:
- Remotely deleted events deleted locally with special button in settings working on 2.27 &
 2.28 servers (https://jira.dhis2.org/browse/ACA-15)
- If no "display in reports" option is selected, "Event date" heading still appears with empty fields and event deletion is prevented (https://jira.dhis2.org/browse/ACA-138)